### PR TITLE
Add motorcycle repair booking platform specification

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,92 @@
+# Motorcycle Repair Booking Platform Specification
+
+## 1. Overview
+A web platform that connects motorcycle owners with local repair shops. The goal is for riders to easily book repair services online while offering shops a tool to manage reservations and attract customers. The platform should be scalable and provide reliable scheduling and optional payment functionality.
+
+## 2. Target Users
+- **Motorcycle owners** – search for shops, book repairs, and track appointments.
+- **Repair shop managers and staff** – list services, manage bookings, and respond to reviews.
+- **Platform administrators** – maintain platform settings, moderate reviews, and handle support.
+
+## 3. Key Features
+### A. For Motorcycle Owners
+- Account sign up/log in via email, phone, or social login.
+- Search repair shops by location, service type, and rating.
+- View shop details: services, prices, hours, customer reviews.
+- Book appointments with real-time availability.
+- Leave ratings and reviews after service.
+- Receive notifications about bookings via SMS, email, or push.
+- Secure payment processing (post-MVP option).
+
+### B. For Repair Shops
+- Create and manage a shop profile.
+- List services with pricing and set operating hours.
+- View, accept, or cancel appointments.
+- Respond to customer reviews.
+- Booking notifications for new appointments.
+- Basic analytics dashboard (daily/weekly bookings and revenue).
+
+### C. Admin Panel
+- Manage user and shop accounts.
+- Moderate reviews and shop content.
+- View overall analytics (users, bookings, revenue).
+- Handle customer support tickets.
+- Configure platform settings (fees, policies, announcements).
+
+## 4. Technical Requirements
+### Frontend
+- Responsive mobile-first UI using **React**.
+- Authentication with JWT and OAuth2 for social logins.
+- Integration with map APIs (Kakao Maps or Google Maps).
+- Component styling with Tailwind or Material UI.
+
+### Backend
+- **FastAPI** to implement a RESTful API.
+- PostgreSQL database.
+- Secure authentication (bcrypt + JWT).
+- Notification system integration (email + SMS).
+- Containerized deployment using Docker (AWS or GCP).
+
+### Other Tools
+- Admin dashboard can be custom-built or use tools like Retool/Firebase Admin SDK.
+- SMS/email services via Twilio and SendGrid.
+- Payments (optional phase 2) with Toss, Stripe, or Bootpay.
+- CI/CD using GitHub Actions.
+
+## 5. MVP Scope
+- User registration and login.
+- Repair shop listing and filtering by location.
+- Booking system with real-time calendar availability.
+- Review and rating submission.
+- Simple shop dashboard to view/edit appointments.
+- Admin panel with core moderation tools.
+
+## 6. Post-MVP Features
+- In-app payments and settlement system.
+- Loyalty program for users.
+- Premium listings for shops.
+- Automated marketing (reminders, abandoned bookings).
+- Mobile app version using React Native or Flutter.
+
+## 7. Design Considerations
+- Accessibility and usability (WCAG compliance).
+- Fast page load on mobile devices.
+- SEO-friendly URLs and metadata.
+- Multilingual support (Korean first, then English).
+- Secure handling of user data (GDPR-like standards).
+
+## 8. Risks & Mitigations
+- **Low shop participation** – start with beta partners and incentives.
+- **Payment disputes** – clear cancellation policy and dedicated support channel.
+- **Abuse or spam** – robust moderation and verification layers.
+
+## 9. Development Timeline (Example)
+- **Month 1**: MVP design, landing page, and backend scaffolding.
+- **Month 2**: Core user/shop flows and booking system.
+- **Month 3**: Testing, admin panel, and public beta.
+- **Month 4+**: Iterate on feedback and introduce monetization features.
+
+## 10. Long-term Vision
+- Become the leading motorcycle maintenance platform in Korea.
+- Expand to scooters, e-bikes, and light EV maintenance.
+- Partner with parts suppliers and insurance companies for a full ecosystem.


### PR DESCRIPTION
## Summary
- add detailed specification for a motorcycle repair booking service

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683fc8a9cfbc8321bf2d1b8dcde582e8